### PR TITLE
Set output address as an array of signed chars in function prototypes

### DIFF
--- a/include/eth_internals.c
+++ b/include/eth_internals.c
@@ -3,7 +3,7 @@
 #include "eth_internals.h"
 
 void getEthAddressStringFromBinary(uint8_t *address,
-                                   uint8_t *out,
+                                   char *out,
                                    cx_sha3_t *sha3Context,
                                    chain_config_t *chain_config) {
     // save some precious stack space

--- a/include/eth_internals.h
+++ b/include/eth_internals.h
@@ -95,7 +95,7 @@ __attribute__((no_instrument_function)) inline int allzeroes(void *buf, size_t n
 static const char HEXDIGITS[] = "0123456789abcdef";
 
 void getEthAddressStringFromBinary(uint8_t *address,
-                                   uint8_t *out,
+                                   char *out,
                                    cx_sha3_t *sha3Context,
                                    chain_config_t *chain_config);
 

--- a/include/eth_internals.h
+++ b/include/eth_internals.h
@@ -55,7 +55,7 @@ typedef struct tokenDefinition_t {
     uint8_t contractName[ADDRESS_LENGTH];
 #endif
     uint8_t address[ADDRESS_LENGTH];
-    uint8_t ticker[MAX_TICKER_LEN];
+    char ticker[MAX_TICKER_LEN];
     uint8_t decimals;
 } tokenDefinition_t;
 


### PR DESCRIPTION
`getEthAddressStringFromBinary` and `getEthAddressStringFromKey` generate a printable address from binary data or from a key.

Output parameter was defined as `uint8_t *`. It seems better to defined it as `char *`. Most (if not all) the calls to these functions in the Ethereum app were casting the output address to `uint8_t *` to prevent a warning.