### PR TITLE
Fix missing copy functions

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 '''
 This script extract a few specific definitions from app-ethereum that are
 required to exchange information with ethereum external plugins.
@@ -172,6 +174,7 @@ if __name__ == "__main__":
     # extract and merge function bodies
     c_files_to_merge = [
         "src/utils.c",
-        "src_common/ethUtils.c"
+        "src_common/ethUtils.c",
+        "src/eth_plugin_internal.c"
     ]
     merge_c_files(c_files_to_merge, nodes_to_extract["fn"])

--- a/include/eth_internals.c
+++ b/include/eth_internals.c
@@ -246,3 +246,13 @@ void u64_to_string(uint64_t src, char *dst, uint8_t dst_size) {
         j++;
     }
 }
+
+void copy_address(uint8_t *dst, uint8_t *parameter, uint8_t dst_size) {
+    uint8_t copy_size = MIN(dst_size, ADDRESS_LENGTH);
+    memmove(dst, parameter + PARAMETER_LENGTH - copy_size, copy_size);
+}
+
+void copy_parameter(uint8_t *dst, uint8_t *parameter, uint8_t dst_size) {
+    uint8_t copy_size = MIN(dst_size, PARAMETER_LENGTH);
+    memmove(dst, parameter, copy_size);
+}


### PR DESCRIPTION
Two functions were included in the header file but were missing from the source file : 
* copy_address
* copy_parameter

Also added a shebang and execution rights to the python build script.