### PR TITLE
B2CA-1558: Port flex

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,3 @@
 
 This repository is meant to be linked as submodule and used in external plugins working with [app-ethereum](https://github.com/LedgerHQ/app-ethereum).
 It is composed of a few headers containing definitions about app-ethereum's internal transaction parsing state and some structures to communicate via shared memory.
-
-## Updating this SDK
-
-This SDK is updated at (app-ethereum) build time every time one of app-ethereum internals structures of interest are modified.
-If this SDK gets updated, it is possible that all plugins must be recompiled (and eventually updated to work again with the update) with this new SDK.
-Be careful, and weight your choices.
-
-## Manual build
-
-If for some reasons you want to rebuild this SDK manually from [app-ethereum](https://github.com/LedgerHQ/app-ethereum) (reminder: it is rebuild automatically when building app-ethereum itself):
-
-```shell
-$> ./tools/build_sdk.sh
-```

--- a/src/common_utils.c
+++ b/src/common_utils.c
@@ -235,7 +235,7 @@ void getEthAddressFromRawKey(const uint8_t raw_pubkey[static 65],
 }
 
 void getEthAddressStringFromRawKey(const uint8_t raw_pubkey[static 65],
-                                   char out[static ADDRESS_LENGTH * 2],
+                                   char out[static (ADDRESS_LENGTH * 2) + 1],
                                    uint64_t chainId) {
     uint8_t hashAddress[CX_KECCAK_256_SIZE];
     CX_ASSERT(cx_keccak_256_hash(raw_pubkey + 1, 64, hashAddress));
@@ -243,7 +243,7 @@ void getEthAddressStringFromRawKey(const uint8_t raw_pubkey[static 65],
 }
 
 bool getEthAddressStringFromBinary(uint8_t *address,
-                                   char out[static ADDRESS_LENGTH * 2],
+                                   char out[static (ADDRESS_LENGTH * 2) + 1],
                                    uint64_t chainId) {
     // save some precious stack space
     union locals_union {
@@ -295,7 +295,7 @@ bool getEthAddressStringFromBinary(uint8_t *address,
             }
         }
     }
-    out[40] = '\0';
+    out[ADDRESS_LENGTH * 2] = '\0';
 
     return true;
 }

--- a/src/common_utils.c
+++ b/src/common_utils.c
@@ -23,6 +23,23 @@
 #include "lcx_ecfp.h"
 #include "lcx_sha3.h"
 
+int array_bytes_string(char *out, size_t outl, const void *value, size_t len) {
+    if (outl <= 2) {
+        // Need at least '0x' and 1 digit
+        return -1;
+    }
+    if (strlcpy(out, "0x", outl) != 2) {
+        goto err;
+    }
+    if (format_hex(value, len, out + 2, outl - 2) < 0) {
+        goto err;
+    }
+    return 0;
+err:
+    *out = '\0';
+    return -1;
+}
+
 uint64_t u64_from_BE(const uint8_t *in, uint8_t size) {
     uint8_t i = 0;
     uint64_t res = 0;

--- a/src/common_utils.c
+++ b/src/common_utils.c
@@ -23,15 +23,6 @@
 #include "lcx_ecfp.h"
 #include "lcx_sha3.h"
 
-void array_hexstr(char *strbuf, const void *bin, unsigned int len) {
-    while (len--) {
-        *strbuf++ = HEXDIGITS[((*((char *) bin)) >> 4) & 0xF];
-        *strbuf++ = HEXDIGITS[(*((char *) bin)) & 0xF];
-        bin = (const void *) ((unsigned int) bin + 1);
-    }
-    *strbuf = 0;  // EOS
-}
-
 uint64_t u64_from_BE(const uint8_t *in, uint8_t size) {
     uint8_t i = 0;
     uint64_t res = 0;

--- a/src/common_utils.h
+++ b/src/common_utils.h
@@ -46,6 +46,8 @@ DEPRECATED static inline void array_hexstr(char *strbuf, const void *bin, unsign
     format_hex(bin, len, strbuf, (2 * len + 1));
 }
 
+int array_bytes_string(char *out, size_t outl, const void *value, size_t len);
+
 uint64_t u64_from_BE(const uint8_t *in, uint8_t size);
 
 bool u64_to_string(uint64_t src, char *dst, uint8_t dst_size);

--- a/src/common_utils.h
+++ b/src/common_utils.h
@@ -22,6 +22,7 @@
 
 #include "os.h"
 #include "cx.h"
+#include "format.h"
 
 #define WEI_TO_ETHER 18
 
@@ -35,7 +36,15 @@ static const char HEXDIGITS[] = "0123456789abcdef";
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
-void array_hexstr(char *strbuf, const void *bin, unsigned int len);
+/**
+ * @deprecated
+ * See format_hex in SDK
+ */
+DEPRECATED static inline void array_hexstr(char *strbuf, const void *bin, unsigned int len)
+{
+    // Consider the output buffer is sufficiently large!
+    format_hex(bin, len, strbuf, (2 * len + 1));
+}
 
 uint64_t u64_from_BE(const uint8_t *in, uint8_t size);
 

--- a/src/common_utils.h
+++ b/src/common_utils.h
@@ -71,11 +71,11 @@ void getEthAddressFromRawKey(const uint8_t raw_pubkey[static 65],
                              uint8_t out[static ADDRESS_LENGTH]);
 
 void getEthAddressStringFromRawKey(const uint8_t raw_pubkey[static 65],
-                                   char out[static ADDRESS_LENGTH * 2],
+                                   char out[static (ADDRESS_LENGTH * 2) + 1],
                                    uint64_t chainId);
 
 bool getEthAddressStringFromBinary(uint8_t *address,
-                                   char out[static ADDRESS_LENGTH * 2],
+                                   char out[static (ADDRESS_LENGTH * 2) + 1],
                                    uint64_t chainId);
 
 bool getEthDisplayableAddress(uint8_t *in, char *out, size_t out_len, uint64_t chainId);

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@
  *****************************************************************************/
 
 #include "eth_plugin_interface.h"
-#include "lib_standard_app/swap_lib_calls.h"  // RUN_APPLICATION
+#include "swap_lib_calls.h"  // RUN_APPLICATION
 
 // Functions implemented by the plugin
 void handle_init_contract(ethPluginInitContract_t *parameters);

--- a/standard_plugin.mk
+++ b/standard_plugin.mk
@@ -25,6 +25,7 @@ APPVERSION ?= "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 # Application source files
 APP_SOURCE_PATH += src ethereum-plugin-sdk
+INCLUDES_PATH += ${BOLOS_SDK}/lib_standard_app
 
 # Application icons following guidelines:
 # https://developers.ledger.com/docs/embedded-app/design-requirements/#device-icon

--- a/standard_plugin.mk
+++ b/standard_plugin.mk
@@ -33,8 +33,9 @@ ICON_NANOS = icons/nanos_app_$(NORMAL_NAME).gif
 ICON_NANOX = icons/nanox_app_$(NORMAL_NAME).gif
 ICON_NANOSP = $(ICON_NANOX)
 ICON_STAX = icons/stax_app_$(NORMAL_NAME).gif
+ICON_FLEX = icons/flex_app_$(NORMAL_NAME).gif
 
-ifeq ($(TARGET_NAME),TARGET_STAX)
+ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_STAX TARGET_FLEX))
     DEFINES += ICONGLYPH=C_stax_$(NORMAL_NAME)_64px
     DEFINES += ICONBITMAP=C_stax_$(NORMAL_NAME)_64px_bitmap
 endif


### PR DESCRIPTION
Add needed stuff to allow using plugins on Flex

Add **Flex** config in `Makefile`.

In addition, fix an potential OOB write in `getEthAddressStringFromBinary`.

And finally, deprecate `array_hexstr`, to be replaced by the SDK function `format_hex`. and add a missing utilisty function `array_bytes_string` (like `format_hex`, but starting the buffer with `0x`).